### PR TITLE
Add cookie config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ cp .env.example .env
 # then edit .env
 ```
 
-3. Adjust `config.yaml` to define the playlist name, output directory and download options.
+3. Adjust `config.yaml` to define the playlist name, output directory and download options. If
+   YouTube requests a sign-in to confirm you're not a bot, export your browser cookies and set
+   `cookie_file` or `cookies_from_browser` under the `download` section to let yt-dlp authenticate.
 
 4. Run the helper:
 

--- a/config.yaml
+++ b/config.yaml
@@ -4,3 +4,7 @@ download:
   output_path: downloads
   format: bestvideo+bestaudio/best
   subtitle_langs: ["en.*"]
+  # Optional: path to cookies.txt exported from your browser
+  # cookie_file: /path/to/cookies.txt
+  # Optional: read cookies directly from a browser profile
+  # cookies_from_browser: chrome

--- a/yt_helper/downloader.py
+++ b/yt_helper/downloader.py
@@ -23,6 +23,12 @@ class Downloader:
         self.opts['format'] = dl_config.get('format', self.opts['format'])
         self.opts['subtitleslangs'] = dl_config.get('subtitle_langs', self.opts['subtitleslangs'])
         self.opts['outtmpl'] = str(self.output_path / '%(playlist)s/%(title)s.%(ext)s')
+        cookie_file = dl_config.get('cookie_file')
+        if cookie_file:
+            self.opts['cookiefile'] = cookie_file
+        browser = dl_config.get('cookies_from_browser')
+        if browser:
+            self.opts['cookiesfrombrowser'] = browser
         self.output_path.mkdir(parents=True, exist_ok=True)
 
     def download(self, urls: Iterable[str]):


### PR DESCRIPTION
## Summary
- add options in `config.yaml` for providing a cookie file or using browser cookies
- let Downloader pass these options to yt-dlp
- document the new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a7b6cc7e0832ba88fbeef3ff1841b