### PR TITLE
Fix cookies_from_browser option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ cp config.yaml.example config.yaml
 
 4. Adjust `config.yaml` to define the playlist name, output directory and download options. If
    YouTube requests a sign-in to confirm you're not a bot, set `cookies_from_browser` under the
-   `download` section to let yt-dlp authenticate using your browser cookies.
+   `download` section to let yt-dlp authenticate using your browser cookies. The extracted
+   cookies will be saved to `youtube_cookies.txt` in the project directory for reuse.
 
 5. Run the helper:
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -5,4 +5,4 @@ download:
   format: bestvideo+bestaudio/best
   subtitle_langs: ["en.*"]
   # Optional: read cookies directly from a browser profile
-  # cookies_from_browser: chrome
+  # cookies_from_browser: chrome  # saves cookies to youtube_cookies.txt

--- a/yt_helper/downloader.py
+++ b/yt_helper/downloader.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Iterable
 
-from yt_dlp import YoutubeDL
+from yt_dlp import YoutubeDL, parse_options
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,14 @@ class Downloader:
         if browser:
             logger.info('Using cookies from browser %s', browser)
             self.opts['cookiefile'] = 'youtube_cookies.txt'
-            self.opts['cookiesfrombrowser'] = browser
+            if isinstance(browser, str):
+                # Reuse yt-dlp's parser to handle KEYRING/PROFILE/CONTAINER syntax
+                self.opts['cookiesfrombrowser'] = parse_options([
+                    f'--cookies-from-browser={browser}'
+                ])[1].cookiesfrombrowser
+            else:
+                # Allow passing tuples directly for advanced usage
+                self.opts['cookiesfrombrowser'] = tuple(browser)
         self.output_path.mkdir(parents=True, exist_ok=True)
 
     def download(self, urls: Iterable[str]):


### PR DESCRIPTION
## Summary
- properly parse `cookies_from_browser` to match yt-dlp CLI behavior
- document saved cookie file in README and config example

## Testing
- `python -m py_compile main.py yt_helper/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685a83414314832bb9ff34a84cd0145b