### PR TITLE
Add manual URL list support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project automates two steps of my personal workflow:
 
-1. Create or locate a playlist on YouTube through the YouTube Data API and list all its video URLs.
+1. Create or locate a playlist on YouTube through the YouTube Data API and list all its video URLs, **or** read a list of URLs directly from `config.yaml`.
 2. Download each video together with its English subtitles using [yt-dlp](https://github.com/yt-dlp/yt-dlp).
 
 The downloaded files are stored locally so they can later be translated to Chinese and played back on Apple TV.
@@ -15,7 +15,7 @@ The downloaded files are stored locally so they can later be translated to Chine
 uv pip install -r requirements.txt
 ```
 
-2. Copy `.env.example` to `.env` and edit it to point to your Google OAuth client secrets JSON.
+2. Copy `.env.example` to `.env` and edit it to point to your Google OAuth client secrets JSON. You can skip this step if `video_urls` is provided in the config.
 
 ```bash
 cp .env.example .env
@@ -27,7 +27,7 @@ cp .env.example .env
 cp config.yaml.example config.yaml
 ```
 
-4. Adjust `config.yaml` to define the playlist name, output directory and download options. If
+4. Adjust `config.yaml` to define either a `playlist_name` or a list of `video_urls`, along with the output directory and download options. If
    YouTube requests a sign-in to confirm you're not a bot, set `cookies_from_browser` under the
    `download` section to let yt-dlp authenticate using your browser cookies. The extracted
    cookies will be saved to `youtube_cookies.txt` in the project directory for reuse.
@@ -38,9 +38,11 @@ cp config.yaml.example config.yaml
 python main.py
 ```
 
-OAuth authentication is required on first run. Afterwards the script will print the playlist URL, list the videos found and download each one with subtitles.
+OAuth authentication is required on first run when using `playlist_name`. If `video_urls` are provided, the script skips Google login. Afterwards the script will print the playlist URL (if any), list the videos found and download each one with subtitles.
 
 ## Obtaining `client_secrets.json`
+
+The following steps are only required when using `playlist_name` to access the YouTube Data API.
 
 1. Sign in to [Google Cloud Console](https://console.cloud.google.com) and create a project.
 2. Configure the consent screen in **APIs & Services → OAuth consent screen** and add test users if necessary.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,4 +1,8 @@
 playlist_name: Example Playlist
+# Alternatively, remove `playlist_name` and provide video URLs directly
+# video_urls:
+#   - https://www.youtube.com/watch?v=dQw4w9WgXcQ
+#   - https://www.youtube.com/watch?v=oHg5SJYRHA0
 
 download:
   output_path: downloads

--- a/main.py
+++ b/main.py
@@ -17,9 +17,15 @@ if CONFIG_FILE.exists():
 else:
     config = {}
 
-playlist = YouTubePlaylist(config)
-urls = list(playlist.video_urls())
-logger.info('Found %d videos in playlist', len(urls))
+
+urls_from_config = config.get('video_urls')
+if urls_from_config:
+    urls = list(urls_from_config)
+    logger.info('Using %d URLs from config', len(urls))
+else:
+    playlist = YouTubePlaylist(config)
+    urls = list(playlist.video_urls())
+    logger.info('Found %d videos in playlist', len(urls))
 
 downloader = Downloader(config)
 downloader.download(urls)


### PR DESCRIPTION
## Summary
- support `video_urls` in config to bypass Google login
- document manual mode in README
- update example config

## Testing
- `python -m py_compile main.py yt_helper/*.py`
- `python main.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a86085a90832b9feca409fb6751a0