### PR TITLE
Skip redownloading existing videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project automates two steps of my personal workflow:
    subtitles which are later translated with OpenAI.
 
 The downloaded files are stored locally so they can later be translated to Chinese and played back on Apple TV.
+Existing video files are detected and skipped, so rerunning the script will only download missing videos.
 
 ## Setup
 

--- a/yt_helper/downloader.py
+++ b/yt_helper/downloader.py
@@ -48,6 +48,11 @@ class Downloader:
         with YoutubeDL(self.opts) as ydl:
             for url in urls:
                 try:
+                    info = ydl.extract_info(url, download=False)
+                    filepath = Path(ydl.prepare_filename(info))
+                    if filepath.exists():
+                        logger.info('Skipping %s; %s already exists', url, filepath)
+                        continue
                     logger.info('Downloading %s', url)
                     ydl.download([url])
                 except Exception as e:


### PR DESCRIPTION
## Summary
- detect existing video files and skip them during download
- document skipping behavior in README

## Testing
- `python -m py_compile main.py yt_helper/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685a94cbf600832b866ee7839bfc5b43