### PR TITLE
Implement forced translation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ cp config.yaml.example config.yaml
    YouTube requests a sign-in to confirm you're not a bot, set `cookies_from_browser` under the
    `download` section to let yt-dlp authenticate using your browser cookies. The extracted
    cookies will be saved to `youtube_cookies.txt` in the project directory for reuse.
+   Set `translate.force` to `true` if you want subtitles translated even when files in the target language already exist.
 
 5. Run the helper to download videos and subtitles:
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -15,3 +15,5 @@ download:
 translate:
   target_lang: zh
   model: gpt-4o-mini
+  # Set to true to always translate even if the target subtitles exist
+  force: false

--- a/yt_helper/translator.py
+++ b/yt_helper/translator.py
@@ -13,6 +13,8 @@ class SubtitleTranslator:
         trans_conf = config.get('translate', {})
         self.target_lang = trans_conf.get('target_lang', 'zh')
         self.model = trans_conf.get('model', 'gpt-4o-mini')
+        # When True, translate even if subtitles in the target language already exist
+        self.force = trans_conf.get('force', False)
         api_key = os.getenv('OPENAI_API_KEY')
         if not api_key:
             logger.warning('OPENAI_API_KEY not set; translation disabled')
@@ -34,7 +36,7 @@ class SubtitleTranslator:
 
             # Skip if any subtitle for the target language already exists
             existing = list(srt.parent.glob(f'{base_name}.{self.target_lang}*.srt'))
-            if existing:
+            if existing and not self.force:
                 logger.info('Skipping %s because target subtitle already exists', srt)
                 processed.add(base_path)
                 continue


### PR DESCRIPTION
## Summary
- add `force` option to translator that translates even when target subtitles exist
- document the new option in README and config example

## Testing
- `python -m py_compile main.py yt_helper/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685a989035d0832ba475d295bb57a42c