### PR TITLE
Add batching option for subtitle translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ cp config.yaml.example config.yaml
    `download` section to let yt-dlp authenticate using your browser cookies. The extracted
    cookies will be saved to `youtube_cookies.txt` in the project directory for reuse.
    Set `translate.force` to `true` if you want subtitles translated even when files in the target language already exist.
+   Use `translate.entries_per_request` to batch multiple subtitle entries into a single OpenAI request.
 
 5. Run the helper to download videos and subtitles:
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -33,3 +33,5 @@ translate:
   # Force translation even if target language subtitles exist
   force: false
   # force: true
+  # Number of subtitle entries to send in each OpenAI request
+  entries_per_request: 1


### PR DESCRIPTION
## Summary
- allow batching multiple subtitle entries in one request
- document new `translate.entries_per_request` option

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab67cf19c832bae6e62ea13846132