### PR TITLE
Add exponential fallback for subtitle batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ cp config.yaml.example config.yaml
    `download` section to let yt-dlp authenticate using your browser cookies. The extracted
    cookies will be saved to `youtube_cookies.txt` in the project directory for reuse.
    Set `translate.force` to `true` if you want subtitles translated even when files in the target language already exist.
-   Use `translate.entries_per_request` to batch multiple subtitle entries into a single OpenAI request.
+    Use `translate.entries_per_request` to batch multiple subtitle entries into a single OpenAI request.
+    When a batch produces fewer translated lines than expected, the translator
+    automatically halves the batch and retries until every line is translated or
+    only single-line requests remain.
 
 5. Run the helper to download videos and subtitles:
 


### PR DESCRIPTION
## Summary
- split batches into halves and retry if the returned translation count does not match the input
- document the new behaviour in the README

## Testing
- `uv pip install --system -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ac1a07ff0832ba9bdeb87a3857748