### PR TITLE
Add configurable multi-threaded fragment download

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ cp config.yaml.example config.yaml
    YouTube requests a sign-in to confirm you're not a bot, set `cookies_from_browser` under the
    `download` section to let yt-dlp authenticate using your browser cookies. The extracted
    cookies will be saved to `youtube_cookies.txt` in the project directory for reuse.
+   Set `download.concurrent_fragment_downloads` to the desired thread count to
+   enable multi-threaded fragment downloads. Leave it unset to disable.
    Set `translate.force` to `true` if you want subtitles translated even when files in the target language already exist.
     Use `translate.entries_per_request` to batch multiple subtitle entries into a single OpenAI request.
     When a batch produces fewer translated lines than expected, the translator

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -22,6 +22,8 @@ download:
   # cookies_from_browser: chrome
   # cookies_from_browser: edge
   # cookies_from_browser: "chrome --profile MyProfile"
+  # Parallel fragment downloads per video
+  # concurrent_fragment_downloads: 4
 
 translate:
   # Target language code, e.g. zh or ja

--- a/yt_helper/downloader.py
+++ b/yt_helper/downloader.py
@@ -39,6 +39,13 @@ class Downloader:
             else:
                 # Allow passing tuples directly for advanced usage
                 self.opts['cookiesfrombrowser'] = tuple(browser)
+
+        threads = dl_config.get('concurrent_fragment_downloads')
+        if threads:
+            try:
+                self.opts['concurrent_fragment_downloads'] = int(threads)
+            except Exception:
+                logger.warning('Invalid concurrent_fragment_downloads: %s', threads)
         self.output_path.mkdir(parents=True, exist_ok=True)
 
     def download(self, urls: Iterable[str]):


### PR DESCRIPTION
## Summary
- allow specifying `download.concurrent_fragment_downloads`
- mention the new option in README
- show example in `config.yaml.example`
- support the option in `Downloader`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b60548014832bb1eef38acef1e7cc