### PR TITLE
Add threaded subtitle translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cp config.yaml.example config.yaml
     When a batch produces fewer translated lines than expected, the translator
     automatically halves the batch and retries until every line is translated or
     only single-line requests remain.
+   Set `translate.threads` to the number of subtitle files to translate in parallel.
 
 5. Run the helper to download videos and subtitles:
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -37,3 +37,5 @@ translate:
   # force: true
   # Number of subtitle entries to send in each OpenAI request
   entries_per_request: 1
+  # Translate multiple files in parallel using this many threads
+  # threads: 2


### PR DESCRIPTION
## Summary
- add `threads` option for translator
- process subtitle files in parallel using ThreadPoolExecutor
- document translator threads option in README and example config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b63033df8832b9c5216baef5069c5