### PR TITLE
Concurrent translation while downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ python main.py
 ```
 
 After the download finishes, the script will automatically translate any English
-subtitles to the configured target language using your OpenAI API key.
+subtitles to the configured target language using your OpenAI API key. The
+translator runs in parallel with the downloader, so translation begins as soon
+as matching ``*.en*.srt`` files appear in the output directory. It keeps
+checking for new files until all downloads are complete. The ``translate.force``
+option still applies when deciding whether to translate existing subtitles.
 
 OAuth authentication is required on first run when using `playlist_name`. If `video_urls` are provided, the script skips Google login. Afterwards the script will print the playlist URL (if any), list the videos found and download each one with subtitles.
 


### PR DESCRIPTION
## Summary
- run translator watch thread alongside downloads
- continuously translate new subtitle files during download
- document parallel translator behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b65743a34832badbfe64f2b746fac