### PR TITLE
Use persistent executor for subtitle translations

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,3 +41,5 @@ downloader.download(urls)
 
 stop_event.set()
 watcher.join()
+
+translator.close()


### PR DESCRIPTION
## Summary
- create `ThreadPoolExecutor` in `SubtitleTranslator.__init__`
- reuse the executor when translating directories
- add `close()` method and call it from `main.py`

## Testing
- `python -m py_compile main.py yt_helper/*.py`
- `pip install PyYAML`

------
https://chatgpt.com/codex/tasks/task_e_685b777362ec832b906c075d45c7098d