### PR TITLE
Reduce noisy logs for cleaner progress display

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,15 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s',
 )
+# Silence noisy libraries and keep only our own output at INFO level
+logging.getLogger().setLevel(logging.WARNING)
+logging.getLogger('httpx').setLevel(logging.WARNING)
+logging.getLogger('openai').setLevel(logging.WARNING)
+logging.getLogger('yt_dlp').setLevel(logging.WARNING)
+logging.getLogger('yt_helper').setLevel(logging.INFO)
+
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 CONFIG_FILE = pathlib.Path('config.yaml')
 assert CONFIG_FILE.exists(), 'config.yaml not found'

--- a/yt_helper/downloader.py
+++ b/yt_helper/downloader.py
@@ -29,7 +29,7 @@ class Downloader:
         self.opts['outtmpl'] = str(self.output_path / '%(playlist)s/%(title)s.%(ext)s')
         browser = dl_config.get('cookies_from_browser')
         if browser:
-            logger.info('Using cookies from browser %s', browser)
+            logger.debug('Using cookies from browser %s', browser)
             self.opts['cookiefile'] = 'youtube_cookies.txt'
             if isinstance(browser, str):
                 # Reuse yt-dlp's parser to handle KEYRING/PROFILE/CONTAINER syntax
@@ -49,7 +49,7 @@ class Downloader:
         self.output_path.mkdir(parents=True, exist_ok=True)
 
     def download(self, urls: Iterable[str]):
-        logger.info('Starting download of %d videos', len(list(urls)))
+        logger.debug('Starting download of %d videos', len(list(urls)))
         # Re-generate iterable because we consumed it to count; easiest approach
         urls = list(urls)
         with YoutubeDL(self.opts) as ydl:
@@ -58,9 +58,9 @@ class Downloader:
                     info = ydl.extract_info(url, download=False)
                     filepath = Path(ydl.prepare_filename(info))
                     if filepath.exists():
-                        logger.info('Skipping %s; %s already exists', url, filepath)
+                        logger.debug('Skipping %s; %s already exists', url, filepath)
                         continue
-                    logger.info('Downloading %s', url)
+                    logger.debug('Downloading %s', url)
                     ydl.download([url])
                 except Exception as e:
                     logger.error('Failed to download %s: %s', url, e)


### PR DESCRIPTION
## Summary
- silence httpx, openai and yt-dlp loggers
- keep our own loggers at INFO
- demote downloader info messages to debug

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_685cf5884364832bb6545eb0d689de8a